### PR TITLE
Added a llink to the forum thread

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -14,6 +14,7 @@
     http://github.com/tidalf/script.module.pyobuz</description>
     <license>GPLv3</license>
     <platform>all</platform>
+    <forum>http://forum.kodi.tv/showthread.php?tid=146568</forum>
     <source>http://github.com/tidalf/script.module.pyobuz</source>
   </extension>
 </addon>


### PR DESCRIPTION
Needed to automatically fill the links on http://kodi.wiki and http://addons.kodi.tv/ sites.
